### PR TITLE
remove esri tags, need to migrate to topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@ compare-maps-template
 =====================
 *Compare Maps*  is a configurable application template used to compare multiple web maps.
 
-[View it live] (http://www.arcgis.com/apps/CompareAnalysis/index.html?appid=37e076cb5893405fbd09d774f350fae2)
+[View it live](http://www.arcgis.com/apps/CompareAnalysis/index.html?appid=37e076cb5893405fbd09d774f350fae2)
 
-#July 2015 Release Updates
+# July 2015 Release Updates
 - **Auto Sync:**  Automatically sync maps to the first map. Disable this behavior by setting auto_sync to false in config/defaults.js 
 - **Search:** Add a search box to each map by setting search to true in config/defaults.js
 
-#Features
+# Features
 
 - Compare multiple web maps side by side.
 - Sync maps based on scale.
@@ -39,25 +39,25 @@ compare-maps-template
 > **Note:** If your application edits features in a feature service, contains secure services or web maps that aren't shared publicly, or generate requests that exceed 200 characters, you may need to set up and use a proxy page. Common situations where you may exceed the URL length are using complex polygons as input to a task or specifying a spatial reference using well-known text (WKT). For details on installing and configuring a proxy page see [Using the proxy](https://developers.arcgis.com/javascript/jshelp/ags_proxy.html). If you do not have an Internet connection, you will need to access and deploy the ArcGIS API for JavaScript documentation from [developers.arcgis.com](https://developers.arcgis.com/).
 
 
-#Requirements
+# Requirements
 
 - Notepad or HTML editor
 - Some background with HTML, CSS and JavaScript
 - Experience with the ArcGIS API for JavaScript is helpful. 
 
-#Resources
+# Resources
 
 - [ArcGIS API for JavaScript Resource Center](http://help.arcgis.com/en/webapi/javascript/arcgis/index.html)
 
-#Issues
+# Issues
 Found a bug or want to request a new feature? Please let us know by submitting an issue. 
 
-#Contributing
-Anyone and everyone is welcome to contribute. 
+# Contributing
+Anyone and everyone is welcome to contribute. Please see our [guidelines for contributing](https://github.com/esri/contributing).
 
-#Licensing 
+# Licensing 
 
-Copyright 2012 Esri
+Copyright 2017 Esri
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 

--- a/README.md
+++ b/README.md
@@ -66,5 +66,3 @@ http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 A copy of the license is available in the repository's license.txt file.
-[](Esri Tags: ArcGIS Online Web Application Templates) 
-[](Esri Language: JavaScript)


### PR DESCRIPTION
custom tags are no longer hidden in parsed markdown.

can you add a `publishing-sharing` (and perhaps your previous Esri Tags) as new [topics](https://github.com/blog/2309-introducing-topics) when you have a moment please?

we are now showcasing this project in https://esri.github.io and need the `publishing-sharing` topic to hydrate a search link.